### PR TITLE
chore: make workflow branch filters and guards branch-agnostic

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   publish:
-    if: github.event_name != 'schedule' || github.ref == 'refs/heads/master'
+    if: github.event_name != 'schedule' || github.ref_name == github.event.repository.default_branch
     uses: EvergineTeam/evergine-standards/.github/workflows/binding-simple-cd.yml@main
     with:
       generator-project: "OpenGLGen/OpenGLGen/OpenGLGen.csproj"  # Path to your generator .csproj

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,9 +14,9 @@ on:
         type: boolean
         default: false
   push:
-    branches: [ "master" ]
+    branches: [ "main", "master" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "main", "master" ]
 
 jobs:
   ci:

--- a/.github/workflows/sync-standards.yml
+++ b/.github/workflows/sync-standards.yml
@@ -16,8 +16,8 @@ on:
         default: "v2"
         required: false
       target_branch:
-        description: "Target branch to apply changes"
-        default: "master"
+        description: "Target branch to apply changes (defaults to the repository default branch)"
+        default: ""
         required: false
       script_path:
         description: "Path where to download the sync script"
@@ -41,7 +41,7 @@ on:
   
 jobs:
   sync:
-    if: github.event_name != 'schedule' || github.ref == 'refs/heads/master'
+    if: github.event_name != 'schedule' || github.ref_name == github.event.repository.default_branch
     permissions:
       contents: write  # allow push commits
       pull-requests: write
@@ -50,7 +50,7 @@ jobs:
       org:  ${{ github.event.inputs.org  || 'EvergineTeam' }}
       repo: ${{ github.event.inputs.repo || 'evergine-standards' }}
       ref:  ${{ github.event.inputs.ref  || 'main' }}
-      target_branch: ${{ github.event.inputs.target_branch || 'main' }}
+      target_branch: ${{ github.event.inputs.target_branch || github.event.repository.default_branch }}
       script_path: ${{ github.event.inputs.script_path || 'sync-standards.ps1' }}
       commit_message: "${{ github.event.inputs.commit_message || vars.STANDARDS_COMMIT_MESSAGE || 'auto: sync standard files [skip ci]' }}"
       mode: ${{ github.event.inputs.mode || 'auto' }}


### PR DESCRIPTION
Preparación para renombrar la rama por defecto de `master` a `main`.

## Por qué

`Sync standards` lleva fallando **todos los meses desde abril de 2026** (4 runs en rojo). La causa es que este repo pasa `target_branch: 'main'` pero su rama por defecto se llama `master`: el reusable hace `ref: ${{ inputs.target_branch }}` en el checkout y el `git fetch origin +refs/heads/main*` nunca resuelve.

De los 15 repos de la flota de bindings, 11 ya usan `main`, y tanto las plantillas oficiales (`evergine-standards-template-*`) como el default de `_sync-standards-reusable.yml` asumen `main`. Este repo es la excepción.

## Qué cambia

- **CI**: los filtros de `push` y `pull_request` aceptan `main` y `master`, para que no haya ninguna ventana sin CI durante el rename.
- **CD y Sync standards**: el guard pasa de `github.ref == 'refs/heads/master'` a `github.ref_name == github.event.repository.default_branch`, que se resuelve en tiempo de ejecución y sobrevive a cualquier rename futuro.
- **Sync standards**: `target_branch` se deriva de la rama por defecto del repo; el input queda con default vacío para que un run manual en blanco también resuelva bien.

## Por qué el guard importa

Si se renombrara la rama sin tocar este `if:`, el cron mensual **se saltaría el job y el run aparecería en verde**: ni publica ni sincroniza, y el badge sigue OK. Es el modo de fallo que hay que eliminar, no solo el rojo actual.

## Fuera de alcance (seguimiento aparte)

Este repo es el único de la flota con los **tres** reusables apuntando a `@main` en vez de `@v2` (`binding-common-ci.yml`, `binding-simple-cd.yml`, `_sync-standards-reusable.yml`). No los toco aquí: `v2` y `main` de `evergine-standards` han divergido (`v2` está 1 commit por delante y **20 por detrás**), así que pinear a `@v2` sería un cambio de comportamiento de CI/CD que merece su propio PR y su propia validación, no ir escondido en un cambio de rama.

## Después de mergear

1. Renombrar `master` → `main`.
2. Lanzar `Sync standards` a mano para confirmar que vuelve a verde.
3. PR de limpieza dejando `branches: [ "main" ]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)