### PR TITLE
chore: consume the bindings toolbox and declare the upstream manifest

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   publish:
     if: github.event_name != 'schedule' || github.ref_name == github.event.repository.default_branch
-    uses: EvergineTeam/evergine-standards/.github/workflows/binding-simple-cd.yml@main
+    uses: EvergineTeam/Evergine.Bindings/.github/workflows/binding-simple-cd.yml@v1
     with:
       generator-project: "OpenGLGen/OpenGLGen/OpenGLGen.csproj"  # Path to your generator .csproj
       generator-name: "OpenGL"                # Name of your generator executable

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   ci:
-    uses: EvergineTeam/evergine-standards/.github/workflows/binding-common-ci.yml@main
+    uses: EvergineTeam/Evergine.Bindings/.github/workflows/binding-common-ci.yml@v1
     with:
       generator-project: "OpenGLGen/OpenGLGen/OpenGLGen.csproj"  # Path to your generator .csproj
       generator-name: "OpenGL"                # Name of your generator executable

--- a/binding.yml
+++ b/binding.yml
@@ -1,0 +1,36 @@
+# Binding manifest — see https://github.com/EvergineTeam/Evergine.Bindings
+# Schema: https://github.com/EvergineTeam/Evergine.Bindings/blob/main/binding.schema.json
+toolbox: 1.0.0
+
+package:
+  id: Evergine.Bindings.OpenGL
+  project: OpenGLGen/Evergine.Bindings.OpenGL/Evergine.Bindings.OpenGL.csproj
+  target-framework: net10.0
+  runtime-identifier: ""
+
+upstream:
+  kind: http-file
+  language: c
+  project: https://github.com/KhronosGroup/OpenGL-Registry
+  version-from: none                # gl.xml carries no single API version; it is a multi-API registry
+  sources:
+    - url: https://raw.githubusercontent.com/KhronosGroup/OpenGL-Registry/main/xml/gl.xml
+      path: KhronosRegistry/gl.xml
+      format: khronos-xml
+
+generator:
+  project: OpenGLGen/OpenGLGen/OpenGLGen.csproj
+  name: OpenGL
+  output:
+    - OpenGLGen/Evergine.Bindings.OpenGL/Generated
+
+# NOTE — this repository is the reason the manifest exists.
+#
+# OpenGL.NET vendors gl.xml exactly like Vulkan.NET vendors vk.xml, but its CD is
+# wired to `binding-simple-cd`, which never downloads anything. Nothing has refreshed
+# this registry since it was committed: the vendored copy is 2,742,329 bytes against
+# 2,772,806 upstream. It is an XML-driven binding wearing a simple binding's clothes.
+#
+# Declaring the source here makes the drift visible and lets binding-updater act on it.
+# Switching the CD over to `binding-xml-cd` is a separate, deliberate change: it alters
+# what gets published, so it does not ride along with the toolbox repoint.


### PR DESCRIPTION
Paso 1 de 4 para incorporar OpenGL.NET a la automatización. Repunta CI y CD al toolbox y añade `binding.yml`.

## Este repo es distinto de los ocho anteriores

Es **el último que seguía consumiendo `evergine-standards@main`** en vez de `@v2`, y eso cambia cómo se verifica.

Las otras ocho migraciones eran no-ops demostrables porque `@v2` y las copias del toolbox son byte-idénticas. Aquí la base es `@main`, y `main` y `v2` **sí han divergido**: `v2` añade el input `nuget-source` y publica con la acción `nuget-publish`, mientras `main` conserva un `dotnet nuget push` inline.

**Una comparación de paquete puede mostrar diferencia real, y sería correcta.** Lo que hay que verificar es que se explique por ese cambio de mecanismo y no por otra cosa.

## Por qué el manifiesto importa más aquí

`KhronosRegistry/gl.xml` **se commiteó por última vez el 7 de mayo de 2019**. Todos los paquetes publicados desde entonces —incluido `2026.4.3.8`, de abril— se generaron de ese registry de hace siete años.

Nada falló, porque OpenGL es una API congelada cuya última versión core (4.6, 2017) es anterior a la copia vendorizada. Pero el desfase es real y medible:

| | Local (2019) | Upstream | Delta |
|---|---|---|---|
| Comandos | 3.256 | 3.298 | **+42** |
| Enums | 6.068 | 6.240 | **+174** |
| Extensiones | 820 | 863 | **+43** |
| Features core | 25 | 25 | 0 |

Cero borrados: el delta es puramente aditivo.

Declarar el upstream es lo que hace ese desfase visible y, en el paso 2, corregible.

## Qué NO entra

`sync-standards.yml` se queda como está, apuntando a `evergine-standards@main`. Es el workflow con dos runs atascados en `queued` desde hace más de 25 horas, y mezclarlo aquí haría imposible saber qué causó qué.

🤖 Generated with [Claude Code](https://claude.com/claude-code)