### PR TITLE
feat: drive CD from the Khronos registry, on a monthly schedule

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -1,6 +1,6 @@
-# Binding Simple CD - Template
+# Binding from XML CD - Template
 
-# This template is for pure .NET bindings (no XML update) to publish NuGets to Nuget.org.
+# This template is for pure .NET bindings with XML update to publish NuGets to Nuget.org.
 # Copy this file to your repository as `.github/workflows/CD.yml` and customize the inputs below.
 
 name: CD
@@ -13,12 +13,16 @@ on:
         required: false
         type: boolean
         default: false
+  schedule:
+    - cron: '30 1 1 * *' # Monthly update on day 1 at 01:30
 
 jobs:
-  publish:
+  cd:
     if: github.event_name != 'schedule' || github.ref_name == github.event.repository.default_branch
-    uses: EvergineTeam/Evergine.Bindings/.github/workflows/binding-simple-cd.yml@v1
+    uses: EvergineTeam/Evergine.Bindings/.github/workflows/binding-xml-cd.yml@v1
     with:
+      xml-url: "https://raw.githubusercontent.com/KhronosGroup/OpenGL-Registry/main/xml/gl.xml"
+      xml-path: "KhronosRegistry/gl.xml"
       generator-project: "OpenGLGen/OpenGLGen/OpenGLGen.csproj"  # Path to your generator .csproj
       generator-name: "OpenGL"                # Name of your generator executable
       binding-project: "OpenGLGen/Evergine.Bindings.OpenGL/Evergine.Bindings.OpenGL.csproj" # Path to your binding .csproj


### PR DESCRIPTION
Paso 2 de 4. Convierte el CD en dirigido por el registry, con cron mensual.

## El problema

OpenGL.NET usaba `binding-simple-cd`, que compila y publica **lo que ya hay en el repo** y nunca mira upstream. Combinado con **no tener `schedule` ninguno**, el binding solo se movía cuando alguien se acordaba de pulsar el botón — y aun entonces regeneraba desde un `gl.xml` de mayo de 2019.

## El cambio

```yaml
on:
  schedule:
    - cron: '30 1 1 * *'   # mismo horario que Vulkan y OpenXR

uses: EvergineTeam/Evergine.Bindings/.github/workflows/binding-xml-cd.yml@v1
with:
  xml-url:  "https://raw.githubusercontent.com/KhronosGroup/OpenGL-Registry/main/xml/gl.xml"
  xml-path: "KhronosRegistry/gl.xml"
```

Con `v1.3.0` eso trae de serie: descargar, regenerar, comparar `Generated/`, commitear registry y código juntos, y **publicar solo si la API cambió de verdad**.

El `if:` que guarda el cron ya era agnóstico de rama, pero hasta ahora era letra muerta porque no había `schedule`.

## Upstream verificado, no supuesto por analogía

- `KhronosGroup/OpenGL-Registry` sirve desde **`main`** — a diferencia de OpenXR-Docs, que sirve desde `master`. Comprobado.
- El registry publica también `glx.xml` y `wgl.xml`, pero **el generador solo lee `gl.xml`**: `Program.cs:12` fija esa ruta y procesa `api = ["gl"]`. Una sola fuente, así que `binding-xml-cd` encaja sin adaptaciones.

## Qué pasará en el primer run

Siete años de desfase se saldan de golpe: **+42 comandos, +174 enums, +43 extensiones, 0 borrados**.

**No lo voy a dejar publicar solo.** El siguiente paso es un CD manual con `skip-assets-publishing: true` para revisar el diff a mano antes de soltar un NuGet con esa acumulación. El generador se escribió contra el `gl.xml` de 2019 y conviene comprobar que digiere las extensiones nuevas.

El job pasa de `publish` a `cd`, igual que en los otros dos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)