### PR TITLE
fix: sync standards from v2, not main

### DIFF
--- a/.github/workflows/sync-standards.yml
+++ b/.github/workflows/sync-standards.yml
@@ -45,11 +45,11 @@ jobs:
     permissions:
       contents: write  # allow push commits
       pull-requests: write
-    uses: EvergineTeam/evergine-standards/.github/workflows/_sync-standards-reusable.yml@main
+    uses: EvergineTeam/evergine-standards/.github/workflows/_sync-standards-reusable.yml@v2
     with:
       org:  ${{ github.event.inputs.org  || 'EvergineTeam' }}
       repo: ${{ github.event.inputs.repo || 'evergine-standards' }}
-      ref:  ${{ github.event.inputs.ref  || 'main' }}
+      ref:  ${{ github.event.inputs.ref  || 'v2' }}
       target_branch: ${{ github.event.inputs.target_branch || github.event.repository.default_branch }}
       script_path: ${{ github.event.inputs.script_path || 'sync-standards.ps1' }}
       commit_message: "${{ github.event.inputs.commit_message || vars.STANDARDS_COMMIT_MESSAGE || 'auto: sync standard files [skip ci]' }}"


### PR DESCRIPTION
`.github/workflows/sync-standards.yml` held two defaults for the same value, and they disagreed:

| | value | who uses it |
|---|---|---|
| `workflow_dispatch.inputs.ref.default` | `"v2"` | manual runs from the UI |
| `with: ref: ${{ github.event.inputs.ref \|\| 'main' }}` | `'main'` | `schedule` runs — cron supplies no inputs |

So a manual sync read `evergine-standards@v2` and the monthly cron read `@main`, and this repository ended up with whichever branch had spoken last. That is what flipped `LICENSE` between `Copyright (c) 2026` and `Copyright (c) 2025` month after month — the copyright year was the visible symptom, not the bug.

`main` in `evergine-standards` has not moved since 2026-03-19; `v2` is twenty commits ahead. Reading `v2` is what the dispatch default already intended.

**Second change, specific to this repository:** it was the only one of the twelve still pinning the reusable at `@main`:

```diff
-    uses: EvergineTeam/evergine-standards/.github/workflows/_sync-standards-reusable.yml@main
+    uses: EvergineTeam/evergine-standards/.github/workflows/_sync-standards-reusable.yml@v2
```

The two versions of that reusable differ today only in how it pins its own composite action (`commit-and-push-or-pr-update@main` vs `@v2`), so this is a no-op right now — verified by diffing both. It stops being one as soon as `v2` moves.

Upstream companions: EvergineTeam/evergine-standards#4 fixes the same line in the template, EvergineTeam/evergine-standards#3 aligns `main`'s licence year so neither branch can reintroduce the flip. This edit is needed here separately because `sync-standards.yml` is not listed in `sync-manifest.json` — the sync never rewrites a consumer's own workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)